### PR TITLE
Added Custom Support for LFS via Cloud Build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,4 +10,5 @@ __pycache__
 .gitattributes
 img/*
 */__pycache__
-tests/*
+/tests/*
+/git_lfs/*

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,55 @@
+steps:
+  - name: 'gcr.io/$PROJECT_ID/git-lfs'
+    args: ['init']
+  - name: 'gcr.io/$PROJECT_ID/git-lfs'
+    args: ['remote', 'add', 'origin', '[REPO_ADDRESS]']
+  - name: 'gcr.io/$PROJECT_ID/git-lfs'
+    args: ['fetch']
+  - name: 'gcr.io/$PROJECT_ID/git-lfs'
+    args: ['reset', '--soft', 'origin/$BRANCH_NAME']
+  - name: 'gcr.io/$PROJECT_ID/git-lfs'
+    args: ['lfs', 'pull']
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - build
+      - '--no-cache'
+      - '-t'
+      - '$_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA'
+      - .
+      - '-f'
+      - Dockerfile
+    id: Build
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - push
+      - '$_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA'
+    id: Push
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+    args:
+      - run
+      - services
+      - update
+      - $_SERVICE_NAME
+      - '--platform=managed'
+      - '--image=$_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA'
+      - >-
+        --labels=managed-by=gcp-cloud-build-deploy-cloud-run,commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID,gcb-trigger-id=$_TRIGGER_ID,$_LABELS
+      - '--region=$_DEPLOY_REGION'
+      - '--quiet'
+    id: Deploy
+    entrypoint: gcloud
+images:
+  - '$_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA'
+options:
+  substitutionOption: ALLOW_LOOSE
+substitutions:
+  _PLATFORM: managed
+  _SERVICE_NAME: food-for-thoughts
+  _LABELS: gcb-trigger-id=294ff71c-609b-4980-96c6-b440df025960
+  _TRIGGER_ID: 294ff71c-609b-4980-96c6-b440df025960
+  _DEPLOY_REGION: asia-southeast1
+  _GCR_HOSTNAME: asia.gcr.io
+tags:
+  - gcp-cloud-build-deploy-cloud-run
+  - gcp-cloud-build-deploy-cloud-run-managed
+  - food-for-thoughts

--- a/git_lfs/Dockerfile
+++ b/git_lfs/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine
+RUN apk --no-cache add git git-lfs
+ENTRYPOINT ["/usr/bin/git"]

--- a/git_lfs/cloudbuild.yaml
+++ b/git_lfs/cloudbuild.yaml
@@ -1,0 +1,5 @@
+steps:
+- name: "gcr.io/cloud-builders/docker"
+  args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/git-lfs', '.']
+images:
+- "gcr.io/$PROJECT_ID/git-lfs"


### PR DESCRIPTION
# Added Features
* Supports pulling LFS files via Cloud Build; which is normally not supported due to an unknown reason.
    * This requires an additional, custom-made git container stored within the Container Registry, full `cloudbuild.yaml` and `Dockerfile` are located within the `git-lfs` folder of this repo.
* Added CD automation via Google Cloud for Cloud Run deployment on every push to `main`
